### PR TITLE
feat: add magento 2.3 compatibility

### DIFF
--- a/Model/Ldap/LdapClient.php
+++ b/Model/Ldap/LdapClient.php
@@ -21,8 +21,8 @@ use Exception;
 use Magenerds\Ldap\Api\LdapClientInterface;
 use Magento\Framework\Exception\LocalizedException;
 use Psr\Log\LoggerInterface;
-use Zend_Ldap;
-use Zend_Ldap_Exception;
+use Zend\Ldap\Ldap;
+use Zend\Ldap\Exception\LdapException;
 
 /**
  * Class LdapClient
@@ -73,7 +73,7 @@ class LdapClient implements LdapClientInterface
         $query = strtr($this->configuration->getUserFilter(), $params);
 
         try {
-            return $this->ldap->search($query, null, Zend_Ldap::SEARCH_SCOPE_ONE);
+            return $this->ldap->search($query, null, Ldap::SEARCH_SCOPE_ONE);
         } catch (Exception $e) {
             $this->logger->error($e->getMessage());
             throw new LocalizedException(__('Login temporarily deactivated. Check your logs for more Information.'));
@@ -86,7 +86,7 @@ class LdapClient implements LdapClientInterface
     public function bind()
     {
         if ($this->ldap === null) {
-            $this->ldap = new Zend_Ldap($this->configuration->getLdapConnectionOptions());
+            $this->ldap = new Ldap($this->configuration->getLdapConnectionOptions());
             $this->ldap->bind();
         }
     }
@@ -98,7 +98,7 @@ class LdapClient implements LdapClientInterface
     {
         try {
             $this->bind();
-        } catch (Zend_Ldap_Exception $e) {
+        } catch (LdapException $e) {
             $this->logger->error($e->getMessage());
             return false;
         }

--- a/composer.json
+++ b/composer.json
@@ -3,10 +3,11 @@
   "description": "LDAP auth for Magento 2 backend login",
   "type": "magento2-module",
   "require": {
-    "php": "~5.6.0|7.0.2|~7.0.6|~7.1.0",
+    "php": "^5.6 || ^7.0",
     "ext-ldap": "*",
-    "magento/framework": "100.0.*|100.1.*|101.0.*",
-    "magenerds/dashboard": "^1.0"
+    "magento/framework": "100.0.*|100.1.*|101.0.*|102.0.*",
+    "magenerds/dashboard": "^1.0",
+    "zendframework/zend-ldap": "^2.10"
   },
   "license": [
     "OSL-3.0"


### PR DESCRIPTION
Hi, I added support for:

- PHP ^7.2
- magento/framework 102.0.*
- zendframework/zend-ldap ^2.10

and minor changes on **LdapClient.php** for the new zend-ldap dependency compatibility.

Many thanks for this module!